### PR TITLE
Bugfix/handle-redot-new-versions

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -20,7 +20,7 @@ get_redot_release_name() {
 
 	redot_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
 	if [ "${platform}" == 'darwin' ]; then
-		if [ "${redot_version}" == "4.3.0-stable" ]
+		if [ "${redot_version}" == "4.3.0-stable" ]; then
 			echo "Redot_v${redot_version}_${mono}macos"
 			exit 0
 		fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ get_release_file_name() {
 	
 	if [ "${platform}" == 'darwin' ]; then
 		# redot 4.3.0 has different zip filename for some reason
-		if [ "${version}" == "4.3-stable" ]; then
+		if [ "${formatted_version}" == "4.3-stable" ] && [ "$tool_name" == "redot"  ]; then
 			echo "${prefix}_v${formatted_version}_macos"
 			exit 0
 		fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -12,24 +12,6 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
-get_redot_release_name() {
-	local version=$1
-	local platform=$2
-	local arch=$3
-	local mono=$4
-
-	redot_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
-	if [ "${platform}" == 'darwin' ]; then
-		if [ "${redot_version}" == "4.3.0-stable" ]; then
-			echo "Redot_v${redot_version}_${mono}macos"
-			exit 0
-		fi
-		# after v4.3.0 the mac filename changes 
-		echo "Redot_v${redot_version}_macos.universal.zip"
-		exit 0
-	fi
-	echo "Redot_v${version}_${mono}${platform}.${arch}"
-}
 
 get_release_file_name() {
 	local version="$1"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ get_release_file_name() {
 	
 	if [ "${platform}" == 'darwin' ]; then
 		# redot 4.3.0 has different zip filename for some reason
-		if [ "${formatted_version}" == "redot-4.3.0" ]; then
+		if [ "${formatted_version}" == "redot-4.3-stable" ]; then
 			echo "${prefix}_v${formatted_version}_macos"
 			exit 0
 		fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ get_release_file_name() {
 	
 	if [ "${platform}" == 'darwin' ]; then
 		# redot 4.3.0 has different zip filename for some reason
-		if [ "${formatted_version}" == "redot-4.3-stable" ]; then
+		if [ "${version}" == "4.3-stable" ]; then
 			echo "${prefix}_v${formatted_version}_macos"
 			exit 0
 		fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,10 +40,10 @@ get_release_file_name() {
 	if [ "${platform}" == 'darwin' ]; then
 		# redot 4.3.0 has different zip filename for some reason
 		if [ "${formatted_version}" == "redot-4.3.0" ]; then
-			echo "${prefix}_v${formatted_version}_${mono}macos"
+			echo "${prefix}_v${formatted_version}_macos"
 			exit 0
 		fi
-		echo "${prefix}_v${formatted_version}_${mono}macos.universal"
+		echo "${prefix}_v${formatted_version}_macos.universal"
 		exit 0
 	fi
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -20,7 +20,7 @@ get_redot_release_name() {
 
 	redot_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
 	if [ "${platform}" == 'darwin' ]; then
-		if [ "${redot_version}" == "redot-4.3.0-stable" ]
+		if [ "${redot_version}" == "4.3.0-stable" ]
 			echo "Redot_v${redot_version}_${mono}macos"
 			exit 0
 		fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -20,31 +20,34 @@ get_release_file_name() {
 	platform=$(uname | tr '[:upper:]' '[:lower:]')
 	arch=$(uname -m)
 	suffix=
+	prefix=
+	formatted_version=
 	if [[ "$ASDF_GODOT_INSTALL_MONO" != "0" ]]; then
 		suffix="mono_${platform}_${arch}"
 	else
 		suffix="${platform}.${arch}"
 	fi
 
-
 	if [ "$tool_name" == "redot" ]; then
-		redot_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
-		if [ "${platform}" == 'darwin' ]; then
-			echo "Redot_v${redot_version}_${mono}macos"
+		prefix="Redot"
+		formatted_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
+	else
+		prefix="Godot"
+		formatted_version=$(echo "$version")
+	fi
+
+	
+	if [ "${platform}" == 'darwin' ]; then
+		# redot 4.3.0 has different zip filename for some reason
+		if [ "${formatted_version}" == "redot-4.3.0" ]; then
+			echo "${prefix}_v${formatted_version}_${mono}macos"
 			exit 0
 		fi
-		echo "Redot_v${redot_version}_${suffix}"
-
+		echo "${prefix}_v${formatted_version}_${mono}macos.universal"
 		exit 0
 	fi
 
-
-	if [ "${platform}" == 'darwin' ]; then
-		echo "Godot_v${version}_${mono}macos.universal"
-		exit 0
-	fi
-
-	echo "Godot_v${version}_${suffix}"
+	echo "${prefix}_v${formatted_version}_${suffix}"
 	
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -12,6 +12,24 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
+get_redot_release_name() {
+	local version=$1
+	local platform=$2
+	local arch=$3
+	local mono=$4
+
+	redot_version=$(echo "$version" | sed 's/redot-\(.*\)/\1/')
+	if [ "${platform}" == 'darwin' ]; then
+		if [ "${redot_version}" == "redot-4.3.0-stable" ]
+			echo "Redot_v${redot_version}_${mono}macos"
+			exit 0
+		fi
+		# after v4.3.0 the mac filename changes 
+		echo "Redot_v${redot_version}_macos.universal.zip"
+		exit 0
+	fi
+	echo "Redot_v${version}_${mono}${platform}.${arch}"
+}
 
 get_release_file_name() {
 	local version="$1"

--- a/test/install.bats
+++ b/test/install.bats
@@ -51,6 +51,14 @@ setup() {
     [[ "$output" == *"redot redot-4.3-stable installation was successful!"* ]]
 }
 
+@test "can install redot 4.3.1" {
+    run asdf install redot redot-4.3.1-stable
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"fail: command not found"* ]] # mac os doesn't have fail installed
+    [[ "$output" == *"redot redot-4.3.1-stable installation was successful!"* ]]
+}
+
+
 
 @test "can install redot latest" {
     # fails now but should look into once i have other parts done

--- a/test/latest-stable.bats
+++ b/test/latest-stable.bats
@@ -7,19 +7,19 @@ setup() {
     ASDF_TMPDIR="$(TMPDIR="${BATS_RUN_TMPDIR}" mktemp -t "test-${BATS_SUITE_TEST_NUMBER}.XXXXXXXXX" -d)"
     ASDF_DATA_DIR="$(bats_readlinkf "${ASDF_TMPDIR}")"
     export ASDF_DATA_DIR
-    asdf plugin-add godot "${ASDF_GODOT}"
-    asdf plugin-add redot "${ASDF_GODOT}"
+    asdf plugin add godot "${ASDF_GODOT}"
+    asdf plugin add redot "${ASDF_GODOT}"
 }
 
 @test "latest stable godot" {
-    run asdf list-all godot
+    run asdf latest godot
     [ "$status" -eq 0 ]
     # match format <version i.e 4.3 or 4.2.2>-<type of release i.e stable, dev>
     [[ "$output" =~ [0-9]\.[0-9](\.[0-9])?\-[a-zA-Z]+ ]]
 }
 
 @test "latest stable redot" {
-    run asdf list-all redot
+    run asdf latest redot
     [ "$status" -eq 0 ]
     # match format <godot or redot>-<version i.e 4.3 or 4.2.2>-<type of release i.e stable, dev>
     [[ "$output" =~ (godot|redot)+\-[0-9]\.[0-9](\.[0-9])?\-[a-zA-Z]+ ]]

--- a/test/list-all.bats
+++ b/test/list-all.bats
@@ -7,20 +7,21 @@ setup() {
     ASDF_TMPDIR="$(TMPDIR="${BATS_RUN_TMPDIR}" mktemp -t "test-${BATS_SUITE_TEST_NUMBER}.XXXXXXXXX" -d)"
     ASDF_DATA_DIR="$(bats_readlinkf "${ASDF_TMPDIR}")"
     export ASDF_DATA_DIR
-    asdf plugin-add godot "${ASDF_GODOT}"
-    asdf plugin-add redot "${ASDF_GODOT}"
+    asdf plugin add godot "${ASDF_GODOT}"
+    asdf plugin add redot "${ASDF_GODOT}"
 }
 
 @test "list all versions godot" {
-    run asdf list-all godot
+    run asdf list all godot
     [ "$status" -eq 0 ]
     # match format <version i.e 4.3 or 4.2.2>-<type of release i.e stable, dev>
     [[ "$output" =~ [0-9]\.[0-9](\.[0-9])?\-[a-zA-Z]+ ]]
 }
 
 @test "list all versions redot" {
-    run asdf list-all redot
+    run asdf list all redot
     [ "$status" -eq 0 ]
+    
     # match format <godot or redot>-<version i.e 4.3 or 4.2.2>-<type of release i.e stable, dev>
     [[ "$output" =~ (godot|redot)+\-[0-9]\.[0-9](\.[0-9])?\-[a-zA-Z]+ ]]
 }


### PR DESCRIPTION
redot 4.3.1 has changed its zip filename for mac os to be more similar to godot so this pr fixes that and makes bat tests asdf 16x+ compatible 